### PR TITLE
enh(apps/longhorn): set xfs to longhorn

### DIFF
--- a/apps/longhorn/longhorn/values.yaml
+++ b/apps/longhorn/longhorn/values.yaml
@@ -6,6 +6,7 @@ longhorn:
   persistence:
     defaultClass: true
     migratable: true
+    defaultFsType: xfs
   preUpgradeChecker:
     jobEnabled: false
   ingress:


### PR DESCRIPTION
## Description

Some apps don't allow ext4 due to `lost+found` folder created by the FS, so switching to something more modern, xfs.