### PR TITLE
fix(apps/longhorn): fix longhorn config node down

### DIFF
--- a/apps/longhorn/longhorn-config/templates/backup.yaml
+++ b/apps/longhorn/longhorn-config/templates/backup.yaml
@@ -1,4 +1,4 @@
-apiVersion: longhorn.io/v1beta1
+apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
   name: backup

--- a/apps/longhorn/longhorn-config/templates/node-down-pod-deletion-policy.yaml
+++ b/apps/longhorn/longhorn-config/templates/node-down-pod-deletion-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: node-down-pod-deletion-policy
+  namespace: longhorn-system
+value: delete-both-statefulset-and-deployment-pod


### PR DESCRIPTION
## Description

> [!WARNING]
> Merge after master node migration

- Rename `secret.yaml` to `backup.yaml`, because it configures backups not a secret
- Add `node-down-pod-deletion-policy` to force-detach PVC and force delete StatefulSet and Deployment when a node is down 