### PR TITLE
bump(apps/longhorn): bump longhorn from 1.6.2 to 1.7.1

### DIFF
--- a/apps/longhorn/longhorn/Chart.yaml
+++ b/apps/longhorn/longhorn/Chart.yaml
@@ -5,5 +5,5 @@ version: 1.0.0
 
 dependencies:
   - name: longhorn
-    version: 1.6.2
+    version: 1.7.1
     repository: https://charts.longhorn.io


### PR DESCRIPTION
> [!WARNING]
> Waiting for 2 weeks before merging and upgrade. (To see if the upgrade is 'safe')